### PR TITLE
Move git branch name to a variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,4 @@ drupal_basic_files_subdir: sites/default/files
 drupal_basic_private_files_directory: "{{drupal_basic_site_dir}}/private"
 # for permissions.yml
 dev_group: drupaldev
+drupal_basic_repo_version: master

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -120,6 +120,7 @@ dependencies:
     - role: ajsalminen.git_checkout
       git_checkout_repo: "{{ drupal_basic_repo }}"
       git_checkout_target: "{{ drupal_basic_site_dir }}"
+      git_checkout_version: "{{ drupal_basic_repo_version }}"
 
     - role: apache_vhost
       apache_vhost_webroot: "{{drupal_basic_site_dir}}/{{drupal_basic_webroot_subdir}}"


### PR DESCRIPTION
This is  not necessary required for the Drupal 10 upgrade in kifiemo, but for sake of convienence it was added.