### PR TITLE
Fix deprecated syntax for compability with newer Ansible versions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,5 +5,7 @@
     src: "{{ drupal_basic_settings_template }}"
     dest: "{{ drupal_basic_site_dir}}/{{drupal_basic_webroot_subdir}}/sites/default/settings.php"
   when: drupal_basic_create_settings
-  
-- include: permissions.yml tags=permissions
+
+- name: Include permissions tasks
+  include_tasks: permissions.yml
+  tags: permissions


### PR DESCRIPTION
Changes "include" to "include_tasks" in main.yml and reformats the include task so the permissions tag works.